### PR TITLE
add pole-mixing to ladder filter, to support more responses

### DIFF
--- a/src/fh_va/ladder.rs
+++ b/src/fh_va/ladder.rs
@@ -10,6 +10,8 @@ use crate::fh_va::FilterParams;
 use std::simd::*;
 use std::sync::Arc;
 
+use super::{LadderMode, get_ladder_mix};
+
 #[allow(dead_code)]
 #[derive(PartialEq, Clone, Copy)]
 enum EstimateSource {
@@ -262,78 +264,3 @@ impl LadderFilter {
         sum
     }
 }
-
-#[derive(Debug, PartialEq)]
-pub enum LadderMode {
-    Lp6,
-    Lp12,
-    Lp18,
-    Lp24,
-    Hp6,
-    Hp12,
-    Hp18,
-    Hp24,
-    Bp12,
-    Bp24,
-    N12,
-}
-impl std::fmt::Display for LadderMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            LadderMode::Lp6 => write!(f, "Lp6"),
-            LadderMode::Lp12 => write!(f, "Lp12"),
-            LadderMode::Lp18 => write!(f, "Lp18"),
-            LadderMode::Lp24 => write!(f, "Lp24"),
-            LadderMode::Hp6 => write!(f, "Hp6"),
-            LadderMode::Hp12 => write!(f, "Hp12"),
-            LadderMode::Hp18 => write!(f, "Hp18"),
-            LadderMode::Hp24 => write!(f, "Hp24"),
-            LadderMode::Bp12 => write!(f, "Bp12"),
-            LadderMode::Bp24 => write!(f, "Bp24"),
-            LadderMode::N12 => write!(f, "N12"),
-        }
-    }
-}
-pub fn get_ladder_mix(mode: LadderMode) -> [f32; 5] {
-    let mix;
-    match mode {
-        LadderMode::Lp6 => {
-            mix = [0., -1., 0., -0., 0.];
-        }
-        LadderMode::Lp12 => {
-            mix = [0., -0., 1., -0., 0.];
-        }
-        LadderMode::Lp18 => {
-            mix = [0., -0., 0., -1., 0.];
-        }
-        LadderMode::Lp24 => {
-            mix = [0., -0., 0., -0., 1.];
-        }
-        LadderMode::Hp6 => {
-            mix = [1., -1., 0., -0., 0.];
-        }
-        LadderMode::Hp12 => {
-            mix = [1., -2., 1., -0., 0.];
-        }
-        LadderMode::Hp18 => {
-            mix = [1., -3., 3., -1., 0.];
-        }
-        LadderMode::Hp24 => {
-            mix = [1., -4., 6., -4., 1.];
-        }
-        LadderMode::Bp12 => {
-            mix = [0., -1., 1., -0., 0.];
-        }
-        LadderMode::Bp24 => {
-            mix = [0., -0., 1., -2., 1.];
-        } 
-        LadderMode::N12 => {
-            mix = [1., -2., 2., -0., 0.];
-
-        },
-          
-    }
-    mix
-}
-
-

--- a/src/fh_va/ladder_plot.rs
+++ b/src/fh_va/ladder_plot.rs
@@ -1,0 +1,68 @@
+// in case you want to plot the ladder's transfer function
+
+fn get_ladder_bode(
+    cutoff: f32,
+    k: f32,
+    ladder_mix: [f32; 5],
+    len: usize,
+) -> Vec<Complex<f32>> {
+    let g = cutoff;
+    let mut frequencies = vec![1.; len];
+    let mut array = vec![Complex::new(0., 0.); len];
+    // frequency map setup
+    const MIN: f32 = 5.;
+    const MAX: f32 = 20000.;
+    let min_log: f32 = MIN.log2();
+    let range: f32 = MAX.log2() - min_log;
+    for i in 0..len {
+        frequencies[i] = 2.0f32.powf(((i as f32 / len as f32) * range) + min_log);
+    }
+    let j = Complex::new(0., 1.);
+    let mut curr_s: Complex<f32>;
+    
+    for i in 0..len {
+        curr_s = frequencies[i] * j;
+        for idx in 0..5 {
+            array[i] += bjt_ladder_base(curr_s, g, k, idx as i32 - 1) * ladder_mix[idx];
+        }
+    }
+        
+    return array;
+}
+
+// all the poles follow this transfer, with pole == 0 for the feedback, pole == 1 for pole 1 etc.
+// when just adding them together according to the pole mix we get the right transfer function
+fn bjt_ladder_base(s: Complex<f32>, g: f32, k: f32, pole: i32) -> Complex<f32> {
+    ((1. + s / g).powi(4 - slope as i32)) / (k + (1. + s / g).powi(4))
+}
+
+pub fn get_amplitude_response(
+    cutoff: f32,
+    k: f32,
+    ladder_mix: [f32; 5],
+    len: usize,
+) -> Vec<f32> {
+    let array = get_ladder_bode(cutoff, k, mode, filter_type, ladder_mix, len);
+    let mut amplitudes = vec![1.; len];
+    for i in 0..len {
+        amplitudes[i] = lin_to_db(array[i].norm());
+    }
+
+    amplitudes
+}
+// phases are in range -PI to PI
+pub fn get_phase_response(
+    cutoff: f32,
+    k: f32,
+    mode: usize,
+    filter_type: Circuits,
+    ladder_mix: [f32; 5],
+    len: usize,
+) -> Vec<f32> {
+    let array = get_filter_bode(cutoff, k, mode, filter_type, ladder_mix, len);
+    let mut phases = vec![1.; len];
+    for i in 0..len {
+        phases[i] = array[i].arg();
+    }
+    phases
+}

--- a/src/fh_va/ladder_plot.rs
+++ b/src/fh_va/ladder_plot.rs
@@ -54,8 +54,6 @@ pub fn get_amplitude_response(
 pub fn get_phase_response(
     cutoff: f32,
     k: f32,
-    mode: usize,
-    filter_type: Circuits,
     ladder_mix: [f32; 5],
     len: usize,
 ) -> Vec<f32> {

--- a/src/fh_va/mod.rs
+++ b/src/fh_va/mod.rs
@@ -88,7 +88,7 @@ impl FilterParams {
     pub fn set_resonance(&mut self, res: f32) {
         self.res = res;
         self.zeta = 5. - 5.0 * res;
-//        self.k_ladder = res.powi(2) * 3.8 - 0.2;
+        //        self.k_ladder = res.powi(2) * 3.8 - 0.2;
         self.k_ladder = res.powi(2) * 4.5 - 0.2;
     }
 
@@ -104,4 +104,77 @@ impl FilterParams {
         self.set_resonance(self.res);
         self.set_frequency(self.cutoff);
     }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum LadderMode {
+    Lp6,
+    Lp12,
+    Lp18,
+    Lp24,
+    Hp6,
+    Hp12,
+    Hp18,
+    Hp24,
+    Bp12,
+    Bp24,
+    N12,
+}
+impl std::fmt::Display for LadderMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            LadderMode::Lp6 => write!(f, "Lp6"),
+            LadderMode::Lp12 => write!(f, "Lp12"),
+            LadderMode::Lp18 => write!(f, "Lp18"),
+            LadderMode::Lp24 => write!(f, "Lp24"),
+            LadderMode::Hp6 => write!(f, "Hp6"),
+            LadderMode::Hp12 => write!(f, "Hp12"),
+            LadderMode::Hp18 => write!(f, "Hp18"),
+            LadderMode::Hp24 => write!(f, "Hp24"),
+            LadderMode::Bp12 => write!(f, "Bp12"),
+            LadderMode::Bp24 => write!(f, "Bp24"),
+            LadderMode::N12 => write!(f, "N12"),
+        }
+    }
+}
+pub fn get_ladder_mix(mode: LadderMode) -> [f32; 5] {
+    let mix;
+    match mode {
+        LadderMode::Lp6 => {
+            mix = [0., -1., 0., -0., 0.];
+        }
+        LadderMode::Lp12 => {
+            mix = [0., -0., 1., -0., 0.];
+        }
+        LadderMode::Lp18 => {
+            mix = [0., -0., 0., -1., 0.];
+        }
+        LadderMode::Lp24 => {
+            mix = [0., -0., 0., -0., 1.];
+        }
+        LadderMode::Hp6 => {
+            mix = [1., -1., 0., -0., 0.];
+        }
+        LadderMode::Hp12 => {
+            mix = [1., -2., 1., -0., 0.];
+        }
+        LadderMode::Hp18 => {
+            mix = [1., -3., 3., -1., 0.];
+        }
+        LadderMode::Hp24 => {
+            mix = [1., -4., 6., -4., 1.];
+        }
+        LadderMode::Bp12 => {
+            mix = [0., -1., 1., -0., 0.];
+        }
+        LadderMode::Bp24 => {
+            mix = [0., -0., 1., -2., 1.];
+        } 
+        LadderMode::N12 => {
+            mix = [1., -2., 2., -0., 0.];
+
+        },
+          
+    }
+    mix
 }


### PR DESCRIPTION
Adds pole mixing to the ladder filter, allowing for more filter responses, basically granting nonlinear highpass/bandpass without having to add more models.

This means that I've removed the resonance gain compensation, since this only works when the filter outputs a lowpass. Makes it a bit more like you'd expect a transistor ladder to be, but also a bit less predictable.

Also adds some code for plotting the transfer function if you want it. I can delete this if not.